### PR TITLE
fix: ie11 bug, also check getAttribute('href')

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -7,10 +7,10 @@ var parser = document.createElement('a');
  * @return {Object}                Object with sorted use elements
  */
 function sortItems(items, element) {
-	var xlink = element.getAttribute('xlink:href');
+	var xlink = element.getAttribute('xlink:href') || element.getAttribute('href');
 
 	// return if xlink just contains fragment
-	if (xlink[0] === '#') {
+	if (!xlink || xlink[0] === '#') {
 		return items;
 	}
 


### PR DESCRIPTION
For some reasons, IE11 (tested the Win7-IE11 VM from modern.ie) sometimes parses the `xlink:href` attributes into a `href` attribute, although it is defined as `xlink:href` in the HTML.

<img width="453" alt="Screenshot 2019-04-09 at 11 51 22" src="https://user-images.githubusercontent.com/949950/55791468-d710cf80-5abe-11e9-93e1-835cad103d91.png">

In my test project, it crashed at the `if (xlink[0] === '#')` because xlink was undefined.
Any idea why this could happen? 

My suggested fix would be to also check for the href attribute 🤷‍♀️ 